### PR TITLE
Fix correct multi-login permission check

### DIFF
--- a/backend/app/admin/service/user_service.py
+++ b/backend/app/admin/service/user_service.py
@@ -169,12 +169,12 @@ class UserService:
                 user = await user_dao.get(db, pk)
                 if not user:
                     raise errors.NotFoundError(msg='用户不存在')
-                multi_login = user.is_multi_login if pk != user.id else request.user.is_multi_login
+                multi_login = user.is_multi_login if pk != request.user.id else request.user.is_multi_login
                 new_multi_login = not multi_login
                 count = await user_dao.set_multi_login(db, pk, multi_login=new_multi_login)
                 token = get_token(request)
                 token_payload = jwt_decode(token)
-                if pk == user.id:
+                if pk == request.user.id:
                     # 系统管理员修改自身时，除当前 token 外，其他 token 失效
                     if not new_multi_login:
                         key_prefix = f'{settings.TOKEN_REDIS_PREFIX}:{user.id}'


### PR DESCRIPTION
## 问题描述

修复用户多端登录权限更新逻辑中错误的当前用户判断。

原代码使用 `pk` 与 `user.id` 进行比较，但 `user` 本身就是根据 `pk` 查询得到的，因此 `pk == user.id` 始终为 `True`，无法正确判断当前操作的目标用户是否为当前登录用户。

这会导致修改其他用户的多端登录权限时，错误地使用当前登录用户的 `is_multi_login` 状态进行判断。

## 修改内容

* 使用 `pk == request.user.id` 判断目标用户是否为当前登录用户。
* 修复多端登录权限关闭时保留当前 Session Token 的判断逻辑。

## 验证

* 已执行 `fba format`。
* 已验证修改当前用户和修改其他用户两种场景下的多端登录权限逻辑。
